### PR TITLE
Linkify the URL to creativecommons.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ we clarify here for external readers:
 
 The documents in this project are licensed under the CC-By 3.0 License, which
 encourages you to share these documents. See
-https://creativecommons.org/licenses/by/3.0/ for more details.
+<https://creativecommons.org/licenses/by/3.0/> for more details.
 
 <a rel="license" href="https://creativecommons.org/licenses/by/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/3.0/88x31.png" /></a>


### PR DESCRIPTION
## What
This PR linkify the URL on the `README.md`. 

## Why
GitHub auto-linkify the URL text but Jekyll doesn't. So in order to linkify the URL on [GitHub pages](https://google.github.io/eng-practices/), we should quate URL with `<` and `>`.

## Screenshots
### Before
<img width="687" alt="before" src="https://user-images.githubusercontent.com/1425259/64419350-af5a7d80-d0d7-11e9-8473-f77a84bad642.png">

### After
<img width="709" alt="after" src="https://user-images.githubusercontent.com/1425259/64419349-af5a7d80-d0d7-11e9-82f0-1c2669984514.png">