### PR TITLE
Clarify inline the CL acronym definition

### DIFF
--- a/review/reviewer/standard.md
+++ b/review/reviewer/standard.md
@@ -14,10 +14,10 @@ submit an improvement to the codebase, then the codebase never improves. Also,
 if a reviewer makes it very difficult for _any_ change to go in, then developers
 are disincentivized to make improvements in the future.
 
-On the other hand, it is the duty of the reviewer to make sure that each CL is
-of such a quality that the overall code health of their codebase is not
-decreasing as time goes on. This can be tricky, because often, codebases degrade
-through small decreases in code health over time, especially when a team is
+On the other hand, it is the duty of the reviewer to make sure that each
+changelist (CL) is of such a quality that the overall code health of their codebase
+is not decreasing as time goes on. This can be tricky, because often, codebases
+degrade through small decreases in code health over time, especially when a team is
 under significant time constraints and they feel that they have to take
 shortcuts in order to accomplish their goals.
 


### PR DESCRIPTION
Maybe not everyone knows what CL stands for, this puts the definition when first used
in the text, to avoid looking up in other places. There is a definition in README.md
however that is not linked and not an obvious way to look into for it.