### PR TITLE
Fix "splitting table" in small-cls.md

### DIFF
--- a/review/developer/small-cls.md
+++ b/review/developer/small-cls.md
@@ -160,13 +160,12 @@ To take this a step further, you could combine these approaches and chart out an
 implementation plan like this, where each cell is its own standalone CL.
 Starting from the model (at the bottom) and working up to the client:
 
-| Layer   | Feature: Multiplication   | Feature: Division               |
-| ------- | ------------------------- | ------------------------------- |
-| Client  | Add button                | Add button                      |
-| API     | Add endpoint              | Add endpoint                    |
-| Service | Implement transformations | Share transformation logic with |
-:         :                           : multiplication                  :
-| Model   | Add proto definition      | Add proto definition            |
+| Layer   | Feature: Multiplication   | Feature: Division                              |
+| ------- | ------------------------- | ---------------------------------------------- |
+| Client  | Add button                | Add button                                     |
+| API     | Add endpoint              | Add endpoint                                   |
+| Service | Implement transformations | Share transformation logic with<br>multiplication |
+| Model   | Add proto definition      | Add proto definition                           |
 
 ## Separate Out Refactorings {#refactoring}
 


### PR DESCRIPTION
In both the Github repository's Markdown viewer and the GitHub.io site [1], the table under "Splitting Horizontally & Vertically" does not render correctly, due to the absence of an extension to regard rows delimited with ":" as continuations of cells from the previous row.

This change unwraps the line markdown so that it will correctly render, maintaining the line wrap in the rendered table with an explicit line break tag.

1: https://google.github.io/eng-practices/review/developer/small-cls.html#splitting-grid