### PR TITLE
Add acceptance criteria validation in functionality section to improve code review performance

### DIFF
--- a/review/reviewer/looking-for.md
+++ b/review/reviewer/looking-for.md
@@ -26,10 +26,9 @@ thinking about edge cases, looking for concurrency problems, trying to think
 like a user, and making sure that there are no bugs that you see just by reading
 the code.
 
-You *can* validate the CL if you want—the time when it's most important for a
+You *can* validate the CL if you want to certify that the code matches the acceptance criteria and user necessities. The time when it's most important for a
 reviewer to check a CL's behavior is when it has a user-facing impact, such as a
-**UI change**. It's hard to understand how some changes will impact a user when
-you're just reading the code. For changes like that, you can have the developer
+**UI change**. It's hard to understand how some changes will impact a user or if the technical solution fulfills all the business necessities when you're just reading the code. For changes like that, you can have the developer
 give you a demo of the functionality if it's too inconvenient to patch in the CL
 and try it yourself.
 


### PR DESCRIPTION
This modification can improve the performance in the code review process for the developer's team.

The documentation talks that its hard to understand how some changes will impact a user just reading the code. However, just the UI changes are mentioned. Actually, the acceptance criteria and business necessity also cannot be validated just by reading the code.

I wrote an article on Linkedin about it right here: [Article about testing code before code review analysis](https://www.linkedin.com/pulse/fac-review-strategy-johnatan-kayevo-obgof/
)

Testing before the coding review flow:
![fac_1](https://github.com/user-attachments/assets/bf86177f-7d1a-4095-bcad-28f9c162f624)

Testing after the coding review flow:
![common_1](https://github.com/user-attachments/assets/f68b2f4a-c4cf-4951-9a5e-18deacce6243)

The results:
![results_1](https://github.com/user-attachments/assets/692b2a2f-34fa-42c0-b1f0-d0da78ff1074)


