### PR TITLE
fix rendering for both jekyll and github

### DIFF
--- a/review/developer/handling-comments.md
+++ b/review/developer/handling-comments.md
@@ -64,11 +64,11 @@ If you can't answer that question, ask the reviewer for clarification.
 And then, if you understand the comments but disagree with them, it's important
 to think collaboratively, not combatively or defensively:
 
-```txt {.bad}
+``` {.bad}
 Bad: "No, I'm not going to do that."
 ```
 
-```txt {.good}
+``` {.good}
 Good: "I went with X because of [these pros/cons] with [these tradeoffs]
 My understanding is that using Y would be worse because of [these reasons].
 Are you suggesting that Y better serves the original tradeoffs, that we should

--- a/review/developer/small-cls.md
+++ b/review/developer/small-cls.md
@@ -164,13 +164,38 @@ To take this a step further, you could combine these approaches and chart out an
 implementation plan like this, where each cell is its own standalone CL.
 Starting from the model (at the bottom) and working up to the client:
 
-| Layer   | Feature: Multiplication   | Feature: Division               |
-| ------- | ------------------------- | ------------------------------- |
-| Client  | Add button                | Add button                      |
-| API     | Add endpoint              | Add endpoint                    |
-| Service | Implement transformations | Share transformation logic with |
-:         :                           : multiplication                  :
-| Model   | Add proto definition      | Add proto definition            |
+<table>
+  <tr>
+    <th>Layer</th>
+    <th>Feature: Multiplication</th>
+    <th>Feature: Division</th>
+  </tr>
+  <tr>
+    <td>Client</td>
+    <td>Add button</td>
+    <td>Add button</td>
+  </tr>
+  <tr>
+    <td>API</td>
+    <td>Add endpoint</td>
+    <td>Add endpoint</td>
+  </tr>
+  <tr>
+    <td>Service</td>
+    <td>Implement transformations</td>
+    <td>Share transformation logic with</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td></td>
+    <td>multiplication</td>
+  </tr>
+  <tr>
+    <td>Model</td>
+    <td>Add proto definition</td>
+    <td>Add proto definition</td>
+  </tr>
+</table>
 
 ## Separate Out Refactorings {#refactoring}
 

--- a/review/developer/small-cls.md
+++ b/review/developer/small-cls.md
@@ -164,38 +164,15 @@ To take this a step further, you could combine these approaches and chart out an
 implementation plan like this, where each cell is its own standalone CL.
 Starting from the model (at the bottom) and working up to the client:
 
-<table>
-  <tr>
-    <th>Layer</th>
-    <th>Feature: Multiplication</th>
-    <th>Feature: Division</th>
-  </tr>
-  <tr>
-    <td>Client</td>
-    <td>Add button</td>
-    <td>Add button</td>
-  </tr>
-  <tr>
-    <td>API</td>
-    <td>Add endpoint</td>
-    <td>Add endpoint</td>
-  </tr>
-  <tr>
-    <td>Service</td>
-    <td>Implement transformations</td>
-    <td>Share transformation logic with</td>
-  </tr>
-  <tr>
-    <td></td>
-    <td></td>
-    <td>multiplication</td>
-  </tr>
-  <tr>
-    <td>Model</td>
-    <td>Add proto definition</td>
-    <td>Add proto definition</td>
-  </tr>
-</table>
+```
+| Layer   | Feature: Multiplication   | Feature: Division               |
+| ------- | ------------------------- | ------------------------------- |
+| Client  | Add button                | Add button                      |
+| API     | Add endpoint              | Add endpoint                    |
+| Service | Implement transformations | Share transformation logic with |
+:         :                           : multiplication                  :
+| Model   | Add proto definition      | Add proto definition            |
+```
 
 ## Separate Out Refactorings {#refactoring}
 


### PR DESCRIPTION
fix #64 (good and bad example rendering correctly for github but not for jekyll)
fix #66 (table rendering badly for both github and jekyll)

for screenshots of proof that the suggested fixes are guaranteed to work for both jekyll and github, see the comment at https://github.com/google/eng-practices/issues/66#issuecomment-2756490669: 
it mentions [website cl-descriptions.html](https://google.github.io/eng-practices/review/developer/cl-descriptions.html#tags) and [github view of cl-descriptions.md](https://github.com/google/eng-practices/blob/master/review/developer/cl-descriptions.md#using-tags-tags)

for convenience, you can see the raw code for cl-descriptions uses "``` {.good}" at https://raw.githubusercontent.com/google/eng-practices/refs/heads/master/review/developer/cl-descriptions.md

and here's what the table looks like now when the raw md code is viewed within vscode:
<img width="545" alt="Screen Shot of table markdown with backticks before and after" src="https://github.com/user-attachments/assets/0f84760c-2c62-4d61-ba56-d21b07d8f93d" />